### PR TITLE
Fix PieFed diagram and endpoint formatting

### DIFF
--- a/docs/ecosystem/piefed.md
+++ b/docs/ecosystem/piefed.md
@@ -99,13 +99,12 @@ Communities federate when users from other instances:
 3. Posts sync to subscribers
 
 ```
-┌──────────────┐     Follow      ┌──────────────┐
-│ piefed.social     │◀────────────────│ lemmy.world  │
-│ /c/programming│                │ (subscriber) │
-└──────────────┘                 └──────────────┘
-       │                                ▲
-       │ Announce(Create(Page))         │
-       └────────────────────────────────┘
+┌─────────────────┐                  ┌─────────────────┐
+│  piefed.social  │◄──── Follow ─────│   lemmy.world   │
+│ /c/programming  │                  │  (subscriber)   │
+└────────┬────────┘                  └────────▲────────┘
+         │                                    │
+         └──── Announce(Create(Page)) ────────┘
 ```
 
 ## Custom Extensions
@@ -122,10 +121,10 @@ Communities federate when users from other instances:
 ### Actor Endpoints
 
 ```
-GET /u/{username}          # Person
-GET /c/{community}         # Group
-GET /post/{id}            # Page
-GET /comment/{id}         # Note
+GET /u/{username}     # Person
+GET /c/{community}    # Group
+GET /post/{id}        # Page
+GET /comment/{id}     # Note
 ```
 
 ### Collections


### PR DESCRIPTION
Improves readability of the PieFed docs:

## Diagram fix
The community federation diagram now has proper box alignment:

```
┌─────────────────┐                  ┌─────────────────┐
│  piefed.social  │◄──── Follow ─────│   lemmy.world   │
│ /c/programming  │                  │  (subscriber)   │
└────────┬────────┘                  └────────▲────────┘
         │                                    │
         └──── Announce(Create(Page)) ────────┘
```

## Endpoint alignment
Actor endpoints now have consistent comment alignment.

Follow-up to #1 - thanks @rimu for the great docs!