### PR TITLE
Default to light mode regardless of system preference

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -61,7 +61,7 @@ const config: Config = {
     colorMode: {
       defaultMode: 'light',
       disableSwitch: false,
-      respectPrefersColorScheme: true,
+      respectPrefersColorScheme: false,
     },
     announcementBar: {
       id: 'contribute',


### PR DESCRIPTION
Fixes #4

Changes `respectPrefersColorScheme` from `true` to `false` so that:

- Site always starts in light mode (better for code readability)
- Users can still manually toggle to dark mode via the switch
- Preference is remembered after manual toggle

Previously, users with system dark mode would see dark theme by default, which may not be optimal for documentation with code examples.