### PR TITLE
Add URIs, IRIs & Linked Data documentation

### DIFF
--- a/docs/concepts/_category_.json
+++ b/docs/concepts/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Core Concepts",
+  "position": 2,
+  "link": {
+    "type": "generated-index",
+    "description": "Foundational concepts for understanding ActivityPub and the Semantic Web."
+  }
+}

--- a/docs/concepts/uris-iris-linked-data.md
+++ b/docs/concepts/uris-iris-linked-data.md
@@ -1,0 +1,251 @@
+---
+sidebar_position: 1
+title: URIs, IRIs & Linked Data
+description: Understanding identifiers and the opacity principle in ActivityPub
+---
+
+# URIs, IRIs & Linked Data
+
+ActivityPub is built on Linked Data principles. Understanding how identifiers work is essential for correct implementations.
+
+## URI vs IRI vs URL
+
+These terms are often confused:
+
+| Term | Meaning | Example |
+|------|---------|---------|
+| **URI** | Uniform Resource Identifier (ASCII only) | `https://example.com/users/alice` |
+| **IRI** | Internationalized Resource Identifier (Unicode) | `https://example.com/用户/アリス` |
+| **URL** | Uniform Resource Locator (a URI you can fetch) | `https://example.com/actor` |
+| **URN** | Uniform Resource Name (persistent identifier) | `urn:isbn:0451450523` |
+
+In practice, ActivityPub uses **IRIs** (which include URIs as a subset). Most implementations treat them as URLs that can be dereferenced via HTTP.
+
+## The Opacity Principle
+
+:::warning Critical Concept
+**IRIs are opaque identifiers.** You cannot infer meaning from the string pattern — only by dereferencing and inspecting the data.
+:::
+
+This is fundamental to Linked Data and RDF. Consider these URLs:
+
+```
+https://mastodon.social/users/alice
+https://mastodon.social/users/alice/followers
+https://example.com/ap/followers/alice
+https://myserver.com/f?user=123
+```
+
+All four could be followers collections. You cannot know from the URL alone — you must:
+
+1. **Fetch** the URL (dereference it)
+2. **Inspect** the `type` property in the response
+3. **Handle** based on what it actually is
+
+### Wrong: Parsing URL Patterns
+
+```javascript
+// ❌ WRONG: Assumes URL structure
+if (recipient.endsWith('/followers')) {
+  // Treat as followers collection
+}
+```
+
+This breaks when servers use different URL patterns.
+
+### Correct: Dereference and Inspect
+
+```javascript
+// ✅ CORRECT: Fetch and check the type
+const data = await fetch(recipient, {
+  headers: { 'Accept': 'application/activity+json' }
+}).then(r => r.json());
+
+if (data.type === 'OrderedCollection' || data.type === 'Collection') {
+  // It's a collection — expand members
+  await expandCollection(data);
+} else if (isActorType(data.type)) {
+  // It's an actor — use their inbox
+  inboxes.add(data.inbox);
+}
+
+function isActorType(type) {
+  return ['Person', 'Service', 'Application', 'Group', 'Organization'].includes(type);
+}
+```
+
+### Where This Applies
+
+The opacity principle applies to **all** ActivityPub URLs:
+
+- **Actor IDs** — Don't parse usernames from URLs
+- **Inbox/Outbox** — Don't assume `/inbox` or `/outbox` paths
+- **Followers/Following** — Don't assume `/followers` or `/following`
+- **Object IDs** — Don't extract post IDs or timestamps from URLs
+
+## Dereferencing
+
+To get data from an IRI, you **dereference** it — make an HTTP GET request.
+
+### Content Negotiation
+
+Request the format you want via the `Accept` header:
+
+```http
+GET /users/alice HTTP/1.1
+Host: example.com
+Accept: application/activity+json
+```
+
+Common formats:
+
+| Accept Header | Format |
+|---------------|--------|
+| `application/activity+json` | ActivityStreams JSON-LD |
+| `application/ld+json` | Generic JSON-LD |
+| `text/html` | Human-readable page |
+
+### Handling Redirects
+
+Servers may redirect. Always follow redirects, but track the canonical ID:
+
+```javascript
+const response = await fetch(url, { redirect: 'follow' });
+const finalUrl = response.url; // May differ from original
+const data = await response.json();
+const canonicalId = data.id; // The authoritative ID
+```
+
+## Fragment Identifiers and httpRange-14
+
+The `#` in a URL denotes a **fragment identifier**:
+
+```
+https://example.com/document#section2
+└──────────────────────────┘ └──────┘
+         base URL           fragment
+```
+
+### The httpRange-14 Problem
+
+A fundamental question in web architecture: **What does a URL identify?**
+
+When you request `https://example.com/alice`:
+- Do you get **Alice** (the person)?
+- Or a **document about Alice**?
+
+This ambiguity led to the W3C TAG's **httpRange-14** resolution, which established:
+
+- If a URL returns `200 OK`, it identifies an **information resource** (a document)
+- If it returns `303 See Other`, it identifies something else (a person, concept, etc.)
+
+### Why Fragments Are Preferred
+
+In **5-star Linked Data**, fragment identifiers solve httpRange-14 elegantly:
+
+```
+https://example.com/alice#me
+└─────────────────────────┘
+```
+
+- The server returns the **document** at `https://example.com/alice`
+- The fragment `#me` identifies **Alice herself** within that document
+- No ambiguity: the document describes Alice, but `#me` *is* Alice
+
+This is why you'll see patterns like:
+
+| Pattern | Identifies |
+|---------|------------|
+| `https://example.com/alice` | Document about Alice |
+| `https://example.com/alice#me` | Alice (the person) |
+| `https://example.com/alice#main-key` | Alice's public key |
+
+### Fragments in ActivityPub
+
+ActivityPub commonly uses fragments for sub-resources:
+
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://example.com/users/alice",
+  "type": "Person",
+  "name": "Alice",
+  "publicKey": {
+    "id": "https://example.com/users/alice#main-key",
+    "owner": "https://example.com/users/alice",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\n..."
+  }
+}
+```
+
+The `#main-key` fragment identifies the key object within Alice's document.
+
+### How Fragments Work
+
+1. The **fragment is not sent to the server** — clients handle it locally
+2. You fetch the base URL, then extract the fragment portion client-side
+3. The server returns one document; the fragment selects part of it
+
+:::tip 5-Star Linked Data
+Using fragment URIs is a best practice in Linked Data because:
+- Clear distinction between documents and things
+- Single HTTP request retrieves related data
+- Avoids httpRange-14 ambiguity
+- Works with RDF and JSON-LD naturally
+:::
+
+## Fediverse Conventions
+
+While IRIs are opaque in principle, the Fediverse has developed common conventions:
+
+| Pattern | Common Meaning |
+|---------|----------------|
+| `/users/{name}` | Actor profile |
+| `/users/{name}/inbox` | Actor inbox |
+| `/users/{name}/outbox` | Actor outbox |
+| `/users/{name}/followers` | Followers collection |
+| `/users/{name}/following` | Following collection |
+| `/@{name}` | Actor (alternative) |
+| `/activities/{id}` | Activity object |
+| `/objects/{id}` | Content object |
+
+:::caution Convention, Not Specification
+These patterns are **conventions**, not requirements. Many servers use different structures:
+
+- Pleroma: `/users/{name}`, `/users/{name}/followers`
+- Lemmy: `/u/{name}`, `/c/{name}`
+- PeerTube: `/accounts/{name}`, `/video-channels/{name}`
+
+**Never rely on URL patterns programmatically.** Always dereference.
+:::
+
+### When Conventions Help
+
+Conventions are useful for:
+- **Debugging** — Quickly identify resource types when reading logs
+- **Documentation** — Explaining typical structures
+- **Heuristics** — Fallback guesses when dereferencing fails
+
+But production code should always dereference first.
+
+## Summary
+
+| Principle | Description |
+|-----------|-------------|
+| **IRIs are opaque** | Don't parse meaning from URL strings |
+| **Dereference first** | Fetch the URL and inspect `type` |
+| **Use fragments** | Prefer `#` URIs for non-document things (5-star LD) |
+| **httpRange-14** | Fragments avoid document/thing ambiguity |
+| **Conventions ≠ specs** | URL patterns are hints, not guarantees |
+
+## Further Reading
+
+- [5-Star Linked Data](https://5stardata.info/) — Tim Berners-Lee's Linked Data principles
+- [httpRange-14](https://www.w3.org/2001/tag/doc/httpRange-14/2007-05-31/HttpRange-14) — W3C TAG resolution
+- [Cool URIs for the Semantic Web](https://www.w3.org/TR/cooluris/) — W3C best practices
+
+## See Also
+
+- **[ActivityStreams Vocabulary](/docs/specs/activitystreams/vocabulary)** — Object and activity types
+- **[Actor Objects](/docs/specs/activitypub/actors)** — Actor structure and properties
+- **[Delivery](/docs/specs/activitypub/delivery)** — Recipient resolution

--- a/docs/specs/activitypub/delivery.md
+++ b/docs/specs/activitypub/delivery.md
@@ -83,7 +83,11 @@ function getRecipients(activity) {
 
 ### Expand Collections
 
-Resolve collection URLs to actual actor inboxes:
+Resolve recipient URLs to actual actor inboxes.
+
+:::warning IRI Opacity
+Don't assume URL patterns like `/followers`. IRIs are opaque — always dereference and check the `type`. See [URIs, IRIs & Linked Data](/docs/concepts/uris-iris-linked-data) for details.
+:::
 
 ```javascript
 async function expandRecipients(recipients) {
@@ -95,28 +99,71 @@ async function expandRecipients(recipients) {
       continue;
     }
 
-    // Check if it's a followers collection
-    if (recipient.endsWith('/followers')) {
-      const actorId = recipient.replace('/followers', '');
-      const followers = await db.followers.find({ actor: actorId });
+    // Dereference the recipient to determine what it is
+    const data = await fetchActivityPubObject(recipient);
+    if (!data) continue;
 
-      for (const follow of followers) {
-        const actor = await fetchActor(follow.follower);
+    const type = Array.isArray(data.type) ? data.type[0] : data.type;
+
+    if (type === 'OrderedCollection' || type === 'Collection') {
+      // It's a collection (e.g., followers) — expand its members
+      const members = await expandCollection(data);
+      for (const memberUrl of members) {
+        const actor = await fetchActor(memberUrl);
         if (actor) {
           inboxes.add(getInbox(actor));
         }
       }
-      continue;
-    }
-
-    // It's an individual actor
-    const actor = await fetchActor(recipient);
-    if (actor) {
-      inboxes.add(getInbox(actor));
+    } else if (isActorType(type)) {
+      // It's an actor — use their inbox directly
+      inboxes.add(getInbox(data));
     }
   }
 
   return inboxes;
+}
+
+// Check if a type is an Actor type
+function isActorType(type) {
+  return ['Person', 'Service', 'Application', 'Group', 'Organization'].includes(type);
+}
+
+// Expand a collection to get member URLs
+async function expandCollection(collection) {
+  const members = [];
+
+  // Handle inline items
+  if (collection.orderedItems) {
+    members.push(...collection.orderedItems);
+  } else if (collection.items) {
+    members.push(...collection.items);
+  }
+
+  // Handle paginated collections (fetch first page)
+  if (collection.first) {
+    const pageUrl = typeof collection.first === 'string'
+      ? collection.first
+      : collection.first.id;
+    const page = await fetchActivityPubObject(pageUrl);
+    if (page?.orderedItems) members.push(...page.orderedItems);
+    if (page?.items) members.push(...page.items);
+  }
+
+  // Normalize to URLs
+  return members.map(m => typeof m === 'string' ? m : m.id);
+}
+
+// Fetch an ActivityPub object with proper headers
+async function fetchActivityPubObject(url) {
+  try {
+    const response = await fetch(url, {
+      headers: { 'Accept': 'application/activity+json' }
+    });
+    if (!response.ok) return null;
+    return await response.json();
+  } catch {
+    return null;
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

Adds foundational documentation on URIs, IRIs, and Linked Data principles. This addresses multiple open issues around identifier handling in ActivityPub.

## Changes

### New: Core Concepts section
- **`/docs/concepts/uris-iris-linked-data`** - Comprehensive guide covering:
  - URI vs IRI vs URL distinctions
  - The opacity principle (don't parse URLs)
  - Dereferencing and content negotiation
  - Fragment identifiers and httpRange-14
  - 5-star Linked Data best practices
  - Fediverse conventions (with caveats)

### Fixed: Delivery documentation
- Updated `expandRecipients()` code example in `/docs/specs/activitypub/delivery`
- Now dereferences recipients and checks `type` instead of assuming URL patterns
- Added warning callout linking to the new concepts page

## Addresses

- Closes #9 - Document URIs, IRIs & Linked Data fundamentals
- Closes #8 - Followers URL does not necessarily end in /followers  
- Closes #6 - Document URI fragment identifiers in RDF/Semantic Web context

## Preview

The new page explains why this is wrong:
```javascript
// ❌ Don't do this
if (recipient.endsWith('/followers')) { ... }
```

And shows the correct approach:
```javascript
// ✅ Do this instead
const data = await fetchActivityPubObject(recipient);
if (data.type === 'OrderedCollection') { ... }
```