### PR TITLE
Fix proofread findings: broken link, emoji cache bug, IETF URLs

### DIFF
--- a/docs/community/resources.md
+++ b/docs/community/resources.md
@@ -183,7 +183,7 @@ note.GetActivityStreamsContent().Set(/* ... */)
 | ActivityStreams 2.0 Core | [w3.org/TR/activitystreams-core](https://www.w3.org/TR/activitystreams-core/) |
 | ActivityStreams 2.0 Vocabulary | [w3.org/TR/activitystreams-vocabulary](https://www.w3.org/TR/activitystreams-vocabulary/) |
 | JSON-LD | [w3.org/TR/json-ld](https://www.w3.org/TR/json-ld/) |
-| WebFinger | [RFC 7033](https://tools.ietf.org/html/rfc7033) |
+| WebFinger | [RFC 7033](https://datatracker.ietf.org/doc/html/rfc7033) |
 
 ### De Facto Standards
 

--- a/docs/concepts/uris-iris-linked-data.md
+++ b/docs/concepts/uris-iris-linked-data.md
@@ -257,6 +257,6 @@ But production code should always dereference first.
 
 ## See Also
 
-- **[ActivityStreams Vocabulary](/docs/specs/activitystreams/vocabulary)** — Object and activity types
+- **[ActivityStreams Overview](/docs/specs/activitystreams/overview)** — Object and activity types
 - **[Actor Objects](/docs/specs/activitypub/actors)** — Actor structure and properties
 - **[Delivery](/docs/specs/activitypub/delivery)** — Recipient resolution

--- a/docs/guides/custom-emoji.md
+++ b/docs/guides/custom-emoji.md
@@ -277,7 +277,7 @@ async function renderContent(note) {
       domain: new URL(emoji.id || emoji.icon.url).hostname
     });
 
-    const url = cached?.localUrl || emoji.icon.url;
+    const url = cached?.url || emoji.icon.url;
     const img = `<img src="${url}" alt="${emoji.name}" class="emoji">`;
 
     // Replace shortcode with image

--- a/docs/specs/webfinger/overview.md
+++ b/docs/specs/webfinger/overview.md
@@ -11,7 +11,7 @@ WebFinger is a protocol for discovering information about users and resources us
 ## Specification
 
 - **Status**: RFC 7033 (September 2013)
-- **URL**: [https://tools.ietf.org/html/rfc7033](https://tools.ietf.org/html/rfc7033)
+- **URL**: [https://datatracker.ietf.org/doc/html/rfc7033](https://datatracker.ietf.org/doc/html/rfc7033)
 
 ## How It Works
 


### PR DESCRIPTION
Fixes #19

A full proofread sweep of all 103 docs pages. Three genuine errors found and fixed:

## Changes

1. **Broken link** — `concepts/uris-iris-linked-data.md` linked to `/docs/specs/activitystreams/vocabulary` which doesn't exist; now points to the ActivityStreams overview.

2. **Code bug** — `guides/custom-emoji.md` rendering example read `cached?.localUrl`, but the emoji cache schema defined earlier on the page only stores `url`/`staticUrl`, so the cached URL was never used. Now reads `cached?.url`.

3. **Outdated URLs** — RFC 7033 links updated from legacy `tools.ietf.org` to canonical `datatracker.ietf.org` in the WebFinger overview and community resources pages.

## Verification

Five parallel proofreading passes covered every section (getting started, concepts, community, ecosystem, guides, reference, specs, tools), checking typos, grammar, markdown structure, internal links, spec facts, and code examples. All other reported candidates were verified and found to be false positives (e.g. Express `res.type()` is valid API, JSX-style SVG is valid MDX, the Node crypto sign/verify examples are correct).