### PR TITLE
Mark activitypub-express as unmaintained

### DIFF
--- a/docs/community/resources.md
+++ b/docs/community/resources.md
@@ -15,7 +15,7 @@ A comprehensive collection of libraries, tools, and resources for building Activ
 | Library | Description | License |
 |---------|-------------|---------|
 | [Fedify](https://fedify.dev/) | Full ActivityPub server framework | MIT |
-| [ActivityPub Express](https://github.com/immers-space/activitypub-express) | Express.js middleware for ActivityPub | MIT |
+| [ActivityPub Express](https://github.com/immers-space/activitypub-express) | Express.js middleware for ActivityPub (unmaintained) | MIT |
 | [express-activitypub](https://github.com/dariusk/express-activitypub) | Simple reference implementation | MIT |
 | [activitystreams-2](https://github.com/activitea/activitystreams-2) | ActivityStreams 2.0 library | Apache-2.0 |
 | [http-signature](https://github.com/joyent/node-http-signature) | HTTP Signatures implementation | MIT |

--- a/docs/ecosystem/fedify.md
+++ b/docs/ecosystem/fedify.md
@@ -284,7 +284,7 @@ fedify dev
 
 **Consider alternatives if:**
 - Building a minimal single-user server → [Fedbox](/docs/ecosystem/fedbox)
-- Need simpler Express integration → activitypub-express
+- Need simpler Express integration → [@fedify/express](https://github.com/fedify-dev/express), or activitypub-express (unmaintained)
 - Want zero dependencies → [microfed](/docs/ecosystem/javascript-libraries#microfed)
 
 ## Resources

--- a/docs/ecosystem/javascript-libraries.md
+++ b/docs/ecosystem/javascript-libraries.md
@@ -30,47 +30,6 @@ Comprehensive TypeScript framework for ActivityPub servers.
 
 **See [dedicated Fedify page](/docs/ecosystem/fedify) for full documentation.**
 
-## activitypub-express
-
-Express.js middleware for ActivityPub.
-
-| Property | Value |
-|----------|-------|
-| Repository | [github.com/immers-space/activitypub-express](https://github.com/immers-space/activitypub-express) |
-| License | MIT |
-| Status | Active |
-
-### Features
-
-- Express.js integration
-- MongoDB storage
-- WebFinger support
-- Activity delivery
-
-### Example
-
-```javascript
-const express = require('express');
-const ActivitypubExpress = require('activitypub-express');
-
-const app = express();
-const apex = ActivitypubExpress({
-  domain: 'example.com',
-  actorParam: 'actor',
-  objectParam: 'id',
-});
-
-app.use(apex);
-
-app.route(apex.routes.actor)
-  .get(apex.net.actor.get)
-  .post(apex.net.actor.post);
-
-app.route(apex.routes.inbox)
-  .get(apex.net.inbox.get)
-  .post(apex.net.inbox.post);
-```
-
 ## microfed
 
 Minimal, modular ActivityPub microservices library.
@@ -129,6 +88,51 @@ const headers = auth.sign({
 import { sign, verify } from 'microfed/auth';
 import { createActor } from 'microfed/profile';
 import { resolve } from 'microfed/webfinger';
+```
+
+## activitypub-express
+
+Express.js middleware for ActivityPub.
+
+:::caution Unmaintained
+activitypub-express has had no activity since 2023 and is currently unmaintained. It still works for existing projects, but avoid it for new ones — see the [discussion on reviving it](https://github.com/socialdocs/socialdocs.org/issues/17).
+:::
+
+| Property | Value |
+|----------|-------|
+| Repository | [github.com/immers-space/activitypub-express](https://github.com/immers-space/activitypub-express) |
+| License | MIT |
+| Status | Unmaintained (last activity 2023) |
+
+### Features
+
+- Express.js integration
+- MongoDB storage
+- WebFinger support
+- Activity delivery
+
+### Example
+
+```javascript
+const express = require('express');
+const ActivitypubExpress = require('activitypub-express');
+
+const app = express();
+const apex = ActivitypubExpress({
+  domain: 'example.com',
+  actorParam: 'actor',
+  objectParam: 'id',
+});
+
+app.use(apex);
+
+app.route(apex.routes.actor)
+  .get(apex.net.actor.get)
+  .post(apex.net.actor.post);
+
+app.route(apex.routes.inbox)
+  .get(apex.net.inbox.get)
+  .post(apex.net.inbox.post);
 ```
 
 ## as2
@@ -222,8 +226,8 @@ const compacted = await jsonld.compact(expanded, {
 | Library | Use Case | Complexity | Features |
 |---------|----------|------------|----------|
 | Fedify | Full server | High | Complete framework |
-| activitypub-express | Express apps | Medium | Middleware |
 | microfed | Minimal server | Low | Modular primitives |
+| activitypub-express | Express apps (unmaintained) | Medium | Middleware |
 | as2 | Types only | Low | Vocabulary |
 | http-signature | Signing | Low | HTTP Signatures |
 
@@ -231,7 +235,7 @@ const compacted = await jsonld.compact(expanded, {
 
 **For new projects**: Use Fedify for comprehensive TypeScript support.
 
-**For existing Express apps**: Use activitypub-express.
+**For existing Express apps**: Fedify integrates with Express via [@fedify/express](https://github.com/fedify-dev/express). activitypub-express was the traditional choice but is now unmaintained.
 
 **For minimal/single-user**: Use microfed with Fedbox.
 

--- a/docs/ecosystem/libraries-overview.md
+++ b/docs/ecosystem/libraries-overview.md
@@ -15,8 +15,8 @@ This page provides an overview of ActivityPub libraries available for different 
 | Library | Description | Status |
 |---------|-------------|--------|
 | [Fedify](https://fedify.dev/) | Modern TypeScript framework | Active |
-| [activitypub-express](https://github.com/immers-space/activitypub-express) | Express.js middleware | Active |
 | [ActivityPub.js](https://github.com/nicksellen/activitypub) | General-purpose library | Maintenance |
+| [activitypub-express](https://github.com/immers-space/activitypub-express) | Express.js middleware | Unmaintained |
 
 [More JavaScript libraries →](/docs/ecosystem/javascript-libraries)
 
@@ -70,7 +70,7 @@ This page provides an overview of ActivityPub libraries available for different 
 
 ### For Quick Prototypes
 
-- **JavaScript**: activitypub-express (easiest setup)
+- **JavaScript**: Fedify (well-documented, active)
 - **Python**: bovine or little-boxes
 - **Go**: go-fed/activity (most complete)
 
@@ -119,12 +119,15 @@ This page provides an overview of ActivityPub libraries available for different 
 
 ### Stable
 
-- activitypub-express (JavaScript)
 - bovine (Python)
 
 ### Experimental
 
 - Various new projects
+
+### Unmaintained
+
+- activitypub-express (JavaScript) — no activity since 2023
 
 ## Building Without a Library
 

--- a/docs/getting-started/choosing-your-stack.md
+++ b/docs/getting-started/choosing-your-stack.md
@@ -37,25 +37,22 @@ Consider these factors when choosing your stack:
 **Best for:** Quick prototypes, web-focused teams, full-stack development
 
 **Popular libraries:**
-- [activitypub-express](https://github.com/immers-space/activitypub-express) - Express middleware
 - [@fedify/fedify](https://fedify.dev/) - Modern TypeScript framework
 - [ActivityPub.js](https://github.com/nicksellen/activitypub) - General-purpose library
+- [activitypub-express](https://github.com/immers-space/activitypub-express) - Express middleware (unmaintained)
 
-```javascript
-// Example with activitypub-express
-const express = require('express');
-const ActivitypubExpress = require('activitypub-express');
+```typescript
+// Example with Fedify
+import { createFederation, MemoryKvStore, Person } from "@fedify/fedify";
 
-const app = express();
-const apex = ActivitypubExpress({
-  domain: 'example.com',
-  actorParam: 'actor',
-  objectParam: 'id'
+const federation = createFederation({ kv: new MemoryKvStore() });
+
+federation.setActorDispatcher("/users/{identifier}", (ctx, identifier) => {
+  return new Person({
+    id: ctx.getActorUri(identifier),
+    preferredUsername: identifier,
+  });
 });
-
-app.use(apex);
-app.get('/u/:actor', apex.net.actor.get);
-app.post('/u/:actor/inbox', apex.net.inbox.post);
 ```
 
 ### Python
@@ -396,7 +393,7 @@ Serverless can be tricky for ActivityPub due to long-running inbox processing an
 
 ```
 Language: JavaScript/TypeScript
-Framework: Express + activitypub-express
+Framework: Fedify (Node.js, Deno, or Bun)
 Database: SQLite
 Deploy: Local or single VPS
 ```


### PR DESCRIPTION
Fixes #17

activitypub-express has had no activity since 2023. As suggested by @Utopiah, this marks it as unmaintained across the docs and moves it down the recommendation lists, while the outreach to the maintainer continues.

## Changes

- **ecosystem/javascript-libraries** — added an "Unmaintained" caution admonition (linking back to #17), changed status, moved the section below microfed, and updated the comparison table and Express recommendation
- **ecosystem/libraries-overview** — status changed to Unmaintained, row moved down, removed from "Stable" maturity tier into a new "Unmaintained" tier, quick-prototype recommendation switched to Fedify
- **getting-started/choosing-your-stack** — library list reordered with unmaintained note, code example swapped from activitypub-express to Fedify, quick-start stack recommendation updated
- **ecosystem/fedify** — comparison note now points Express users to [@fedify/express](https://github.com/fedify-dev/express) (verified on npm)
- **community/resources** — unmaintained note added to the table entry

The library remains documented throughout — existing users can still find it — it's just no longer recommended for new projects.