### PR TITLE
Link timbl's Design Issues and REST from Linked Data page

### DIFF
--- a/docs/concepts/uris-iris-linked-data.md
+++ b/docs/concepts/uris-iris-linked-data.md
@@ -250,10 +250,25 @@ But production code should always dereference first.
 
 ## Further Reading
 
+### Tim Berners-Lee's Design Issues
+
+The source documents for the principles on this page:
+
+- [Axioms of Web Architecture](https://www.w3.org/DesignIssues/Axioms.html) — universality and opacity of URIs
+- [What do HTTP URIs Identify?](https://www.w3.org/DesignIssues/HTTP-URI.html) — the document/thing question
+- [Linked Data](https://www.w3.org/DesignIssues/LinkedData.html) — the four Linked Data principles and the 5-star scheme
+- [Cool URIs don't change](https://www.w3.org/Provider/Style/URI) — designing identifiers that last
+
+### REST and the httpRange-14 Debate
+
+- [Architectural Styles: REST](https://roy.gbiv.com/pubs/dissertation/rest_arch_style.htm) — Roy Fielding's dissertation chapter defining REST, the architecture beneath HTTP and ActivityPub
+- [Roy Fielding on HTTP Dereference (2002)](https://lists.w3.org/Archives/Public/www-tag/2002Mar/0121.html) — The httpRange-14 debate origins: Fielding (REST creator) argues HTTP URIs don't imply documents; Berners-Lee counters that fragments enable subdividing documents into things. Both perspectives shaped modern Linked Data.
+
+### Specifications & Notes
+
 - [5-Star Linked Data](https://5stardata.info/) — Tim Berners-Lee's Linked Data principles
 - [httpRange-14](https://www.w3.org/2001/tag/doc/httpRange-14/2007-05-31/HttpRange-14) — W3C TAG resolution
 - [Cool URIs for the Semantic Web](https://www.w3.org/TR/cooluris/) — W3C best practices
-- [Roy Fielding on HTTP Dereference (2002)](https://lists.w3.org/Archives/Public/www-tag/2002Mar/0121.html) — The httpRange-14 debate origins: Fielding (REST creator) argues HTTP URIs don't imply documents; Berners-Lee counters that fragments enable subdividing documents into things. Both perspectives shaped modern Linked Data.
 
 ## See Also
 


### PR DESCRIPTION
Fixes #15

Restructures the Further Reading section of the URIs, IRIs & Linked Data page into three groups:

- **Tim Berners-Lee's Design Issues** — Axioms of Web Architecture, What do HTTP URIs Identify?, Linked Data, and Cool URIs don't change
- **REST and the httpRange-14 debate** — Fielding's dissertation chapter on REST, plus the existing 2002 www-tag post
- **Specifications & Notes** — the existing 5-star, httpRange-14 TAG resolution, and Cool URIs links

Notes:
- The issue suggested `w3.org/DesignIssues/REST.html`, but that URL is a 404 — there is no timbl Design Issue on REST. Substituted the canonical source: Fielding's dissertation chapter on Fielding's own site (`roy.gbiv.com`).
- All five new URLs verified returning 200.