### PR TITLE
Fix SVG diagram overlaps and clipping

### DIFF
--- a/docs/guides/following-and-followers.md
+++ b/docs/guides/following-and-followers.md
@@ -66,9 +66,6 @@ The follow mechanism is fundamental to ActivityPub. It establishes relationships
   <text x="280" y="159" textAnchor="middle" fill="white" fontSize="10" fontWeight="600">6</text>
   <text x="300" y="159" fill="currentColor" fontSize="11" fontWeight="500">Posts now delivered to Alice</text>
 
-  {/* Connection */}
-  <line x1="180" y1="155" x2="265" y2="55" stroke="#6364FF" strokeWidth="1.5" strokeDasharray="5,3"/>
-
   {/* Result */}
   <rect x="130" y="195" width="240" height="65" rx="8" fill="url(#followGrad)" stroke="#6364FF" strokeWidth="1.5"/>
   <text x="250" y="218" textAnchor="middle" fill="#6364FF" fontSize="12" fontWeight="600">Follow Relationship Established</text>

--- a/docs/guides/handling-incoming-activities.md
+++ b/docs/guides/handling-incoming-activities.md
@@ -52,9 +52,9 @@ When other servers send activities to your inbox, you need to verify them and pr
   <text x="200" y="248" textAnchor="middle" fill="white" fontSize="11" fontWeight="600">Return 202 Accepted</text>
 
   {/* Side annotations */}
-  <text x="315" y="89" fill="currentColor" fontSize="9" opacity="0.7">→ 401 if invalid</text>
-  <text x="315" y="142" fill="currentColor" fontSize="9" opacity="0.7">→ 400 if malformed</text>
-  <text x="315" y="195" fill="currentColor" fontSize="9" opacity="0.7">→ 403 if blocked</text>
+  <text x="388" y="89" textAnchor="end" fill="currentColor" fontSize="9" opacity="0.7">→ 401 if invalid</text>
+  <text x="388" y="142" textAnchor="end" fill="currentColor" fontSize="9" opacity="0.7">→ 400 if malformed</text>
+  <text x="388" y="195" textAnchor="end" fill="currentColor" fontSize="9" opacity="0.7">→ 403 if blocked</text>
 </svg>
 
 ## Setting Up the Inbox

--- a/docs/guides/testing-your-implementation.md
+++ b/docs/guides/testing-your-implementation.md
@@ -24,22 +24,22 @@ Building an ActivityPub implementation requires thorough testing to ensure compa
   {/* E2E - Top */}
   <polygon points="230,50 280,90 180,90" fill="url(#testGrad)" stroke="#6364FF" strokeWidth="1.5"/>
   <text x="230" y="78" textAnchor="middle" fill="currentColor" fontSize="10" fontWeight="500">E2E</text>
-  <text x="340" y="75" fill="currentColor" fontSize="10" opacity="0.8">Federation tests</text>
+  <text x="448" y="75" textAnchor="end" fill="currentColor" fontSize="10" opacity="0.8">Federation tests</text>
 
   {/* Integration */}
   <polygon points="180,90 280,90 310,130 150,130" fill="url(#testGrad)" stroke="#6364FF" strokeWidth="1.5"/>
   <text x="230" y="117" textAnchor="middle" fill="currentColor" fontSize="10" fontWeight="500">Integration</text>
-  <text x="370" y="115" fill="currentColor" fontSize="10" opacity="0.8">Component tests</text>
+  <text x="448" y="115" textAnchor="end" fill="currentColor" fontSize="10" opacity="0.8">Component tests</text>
 
   {/* Unit Tests */}
   <polygon points="150,130 310,130 350,170 110,170" fill="url(#testGrad)" stroke="#6364FF" strokeWidth="1.5"/>
   <text x="230" y="157" textAnchor="middle" fill="currentColor" fontSize="10" fontWeight="500">Unit Tests</text>
-  <text x="390" y="155" fill="currentColor" fontSize="10" opacity="0.8">Function tests</text>
+  <text x="448" y="155" textAnchor="end" fill="currentColor" fontSize="10" opacity="0.8">Function tests</text>
 
   {/* Static Analysis - Base */}
   <polygon points="110,170 350,170 380,200 80,200" fill="url(#testGrad)" stroke="#6364FF" strokeWidth="2"/>
   <text x="230" y="192" textAnchor="middle" fill="currentColor" fontSize="10" fontWeight="600">Static Analysis</text>
-  <text x="25" y="192" fill="currentColor" fontSize="9" opacity="0.8">Linting, types</text>
+  <text x="15" y="192" fill="currentColor" fontSize="9" opacity="0.8">Linting, types</text>
 </svg>
 
 ## Test Suites

--- a/docs/specs/http-signatures/overview.md
+++ b/docs/specs/http-signatures/overview.md
@@ -15,14 +15,14 @@ HTTP Signatures provide authentication for ActivityPub federation. When a server
 
 ## How It Works
 
-<svg viewBox="0 0 480 200" style={{maxWidth: '480px', width: '100%', height: 'auto'}}>
+<svg viewBox="0 0 480 330" style={{maxWidth: '480px', width: '100%', height: 'auto'}}>
   <defs>
     <linearGradient id="sigGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style={{stopColor: '#6364FF', stopOpacity: 0.12}}/>
       <stop offset="100%" style={{stopColor: '#8b5cf6', stopOpacity: 0.12}}/>
     </linearGradient>
   </defs>
-  <rect x="5" y="5" width="470" height="190" rx="12" fill="none" stroke="#6364FF" strokeWidth="2"/>
+  <rect x="5" y="5" width="470" height="320" rx="12" fill="none" stroke="#6364FF" strokeWidth="2"/>
 
   {/* Step 1 */}
   <circle cx="30" cy="35" r="14" fill="#6364FF"/>
@@ -47,24 +47,27 @@ HTTP Signatures provide authentication for ActivityPub federation. When a server
   <text x="30" y="140" textAnchor="middle" fill="white" fontSize="11" fontWeight="600">3</text>
   <text x="52" y="140" fill="currentColor" fontSize="11" fontWeight="500">Receiver fetches sender's public key from actor</text>
 
-  {/* Step 4-5 on right */}
-  <circle cx="280" cy="85" r="14" fill="#6364FF"/>
-  <text x="280" y="90" textAnchor="middle" fill="white" fontSize="11" fontWeight="600">4</text>
-  <text x="302" y="90" fill="currentColor" fontSize="11" fontWeight="500">Receiver verifies signature</text>
+  {/* Arrow */}
+  <line x1="30" y1="152" x2="30" y2="165" stroke="#6364FF" strokeWidth="2" strokeDasharray="3,2"/>
+  <polygon points="27,162 30,170 33,162" fill="#6364FF"/>
 
-  <line x1="280" y1="102" x2="280" y2="115" stroke="#6364FF" strokeWidth="2" strokeDasharray="3,2"/>
-  <polygon points="277,112 280,120 283,112" fill="#6364FF"/>
+  {/* Step 4 */}
+  <circle cx="30" cy="185" r="14" fill="#6364FF"/>
+  <text x="30" y="190" textAnchor="middle" fill="white" fontSize="11" fontWeight="600">4</text>
+  <text x="52" y="190" fill="currentColor" fontSize="11" fontWeight="500">Receiver verifies signature</text>
 
-  <circle cx="280" cy="135" r="14" fill="#6364FF"/>
-  <text x="280" y="140" textAnchor="middle" fill="white" fontSize="11" fontWeight="600">5</text>
-  <text x="302" y="140" fill="currentColor" fontSize="11" fontWeight="500">If valid, process request</text>
+  {/* Arrow */}
+  <line x1="30" y1="202" x2="30" y2="215" stroke="#6364FF" strokeWidth="2" strokeDasharray="3,2"/>
+  <polygon points="27,212 30,220 33,212" fill="#6364FF"/>
 
-  {/* Connection line */}
-  <line x1="120" y1="135" x2="265" y2="85" stroke="#6364FF" strokeWidth="1.5" strokeDasharray="5,3"/>
+  {/* Step 5 */}
+  <circle cx="30" cy="235" r="14" fill="#6364FF"/>
+  <text x="30" y="240" textAnchor="middle" fill="white" fontSize="11" fontWeight="600">5</text>
+  <text x="52" y="240" fill="currentColor" fontSize="11" fontWeight="500">If valid, process request</text>
 
   {/* Result indicator */}
-  <rect x="350" y="155" width="110" height="30" rx="6" fill="url(#sigGrad)" stroke="#6364FF" strokeWidth="1"/>
-  <text x="405" y="175" textAnchor="middle" fill="#6364FF" fontSize="11" fontWeight="500">✓ Authenticated</text>
+  <rect x="52" y="270" width="130" height="30" rx="6" fill="url(#sigGrad)" stroke="#6364FF" strokeWidth="1"/>
+  <text x="117" y="290" textAnchor="middle" fill="#6364FF" fontSize="11" fontWeight="500">✓ Authenticated</text>
 </svg>
 
 ## Signature Header Format


### PR DESCRIPTION
Fixes #23

## Re-audit first

The initial audit in #23 reported 19 broken diagrams, but it had a harness bug: the test renderer fed JSX camelCase attributes (`textAnchor`, `strokeWidth`) straight to Chromium, where they're ignored — React converts them correctly on the live site. After fixing the harness and re-rendering all 22 diagrams, only **4 real defects** remained:

## Fixes

1. **specs/http-signatures/overview** (the one genuinely broken one) — the 5-step flow used two columns whose text collided; rebuilt as a single vertical column with the ✓ Authenticated result at the bottom
2. **guides/handling-incoming-activities** — "→ 400 if malformed" clipped at the right viewBox edge; side annotations now right-aligned with `textAnchor="end"`
3. **guides/testing-your-implementation** — "Component tests"/"Function tests" clipped at the right edge and "Linting, types" touched the pyramid base; labels right-aligned and nudged
4. **guides/following-and-followers** — removed the decorative diagonal connector that crossed the "Accept or Reject" text

## Verification

Each SVG was extracted, JSX-converted, and rendered headless in Chromium with the site's sans-serif font stack — before and after. All four now render cleanly; the other 18 diagrams were confirmed fine as-is.