### PR TITLE
Link boyter/activitypub sequence diagrams from guides and resources

### DIFF
--- a/docs/community/resources.md
+++ b/docs/community/resources.md
@@ -203,6 +203,12 @@ note.GetActivityStreamsContent().Set(/* ... */)
 | [How to Implement ActivityPub](https://blog.joinmastodon.org/2018/06/how-to-implement-a-basic-activitypub-server/) | Mastodon blog tutorial |
 | [Building an ActivityPub Server](https://socialhub.activitypub.rocks/t/building-an-activitypub-server/2019) | SocialHub discussion |
 
+### Diagrams & Visual References
+
+| Resource | Description |
+|----------|-------------|
+| [boyter/activitypub](https://github.com/boyter/activitypub) | Sequence diagrams for common flows: Follow, Create, Delete, Announce, Move, WebFinger — a "clean room" implementation reference (MIT) |
+
 ### Video Content
 
 | Resource | Description |

--- a/docs/guides/account-migration.md
+++ b/docs/guides/account-migration.md
@@ -442,3 +442,4 @@ async function canMigrate(actor) {
 - **[Content Moderation](/docs/guides/content-moderation)** - Handling abuse
 - **[Scaling and Performance](/docs/guides/scaling-and-performance)** - Infrastructure
 - **[Authentication and Security](/docs/getting-started/authentication-and-security)** - Security model
+- **[Move sequence diagram](https://github.com/boyter/activitypub/blob/main/move-post.md)** - External reference for the migration exchange

--- a/docs/guides/following-and-followers.md
+++ b/docs/guides/following-and-followers.md
@@ -524,3 +524,4 @@ Accept/Reject may arrive before you've stored the Follow request. Handle this by
 - **[Posts and Replies](/docs/guides/posts-and-replies)** - Creating content
 - **[Likes and Shares](/docs/guides/likes-and-shares)** - Engagement activities
 - **[Direct Messages](/docs/guides/direct-messages)** - Private messaging
+- **[Follow sequence diagram](https://github.com/boyter/activitypub/blob/main/follow-post.md)** - External reference showing the full server-to-server exchange

--- a/docs/guides/likes-and-shares.md
+++ b/docs/guides/likes-and-shares.md
@@ -511,3 +511,4 @@ function getOriginalAuthor(activity) {
 - **[Direct Messages](/docs/guides/direct-messages)** - Private messaging
 - **[Mentions and Hashtags](/docs/guides/mentions-and-hashtags)** - Tagging
 - **[Mastodon Compatibility](/docs/guides/mastodon-compatibility)** - Implementation details
+- **[Announce sequence diagram](https://github.com/boyter/activitypub/blob/main/announce-post.md)** - External reference for the boost exchange

--- a/docs/guides/posts-and-replies.md
+++ b/docs/guides/posts-and-replies.md
@@ -572,3 +572,4 @@ async function deliverToRecipients(activity, author) {
 - **[Likes and Shares](/docs/guides/likes-and-shares)** - Engagement activities
 - **[Mentions and Hashtags](/docs/guides/mentions-and-hashtags)** - Tagging content
 - **[Media Attachments](/docs/guides/media-attachments)** - Adding images and video
+- **[Create](https://github.com/boyter/activitypub/blob/main/create-post.md) / [Delete](https://github.com/boyter/activitypub/blob/main/delete-post.md) sequence diagrams** - External reference for the delivery exchanges

--- a/docs/guides/webfinger-implementation.md
+++ b/docs/guides/webfinger-implementation.md
@@ -448,3 +448,4 @@ async function cachedWebFinger(handle) {
 - **[Testing Your Implementation](/docs/guides/testing-your-implementation)** - Validation
 - **[HTTP Signatures](/docs/specs/http-signatures/overview)** - Authentication
 - **[Building an Actor](/docs/guides/building-an-actor)** - Creating actors
+- **[WebFinger sequence diagram](https://github.com/boyter/activitypub/blob/main/webfinger.md)** - External reference for the discovery exchange


### PR DESCRIPTION
Fixes #14

Adds the [boyter/activitypub](https://github.com/boyter/activitypub) sequence diagrams (recommended on the SWICG mailing list) as external references:

- **community/resources** — new "Diagrams & Visual References" subsection under Learning Resources
- **guides/following-and-followers** — Follow diagram in Next Steps
- **guides/posts-and-replies** — Create / Delete diagrams
- **guides/likes-and-shares** — Announce diagram
- **guides/account-migration** — Move diagram
- **guides/webfinger-implementation** — WebFinger diagram

We link rather than embed: the repo is MIT so embedding is possible later, but the diagrams are high-level and the upstream repo accepts PRs, so a pointer keeps them current without maintenance burden here.

All six links verified to resolve (the repo's default branch is `main`, not `master`).