### PR TITLE
June 2026 content refresh: stats, standards status, feature claims

### DIFF
--- a/docs/community/events.md
+++ b/docs/community/events.md
@@ -42,7 +42,7 @@ The Fediverse community organizes conferences, unconferences, and meetups throug
 - How the Fediverse Can Help Artists Thrive
 
 **Upcoming Events:**
-- Check [fediforum.org](https://fediforum.org/) for dates
+- Next edition: **October 6-7, 2026** — see [fediforum.org](https://fediforum.org/) for registration and the [events archive](https://fediforum.org/events/) for past sessions
 
 ### FediCon
 

--- a/docs/community/socialcg.md
+++ b/docs/community/socialcg.md
@@ -137,15 +137,15 @@ Manages specification corrections:
 
 ## Current Initiatives
 
-### New Working Group Charter
+### Social Web Working Group (Rechartered)
 
-The W3C is considering a new Working Group to:
+In January 2026, the W3C rechartered the [Social Web Working Group](/docs/ecosystem/w3c-groups) (chaired by Darius Kazemi) to:
 
-- Make backwards-compatible updates to specifications
-- Address implementation experience feedback
-- Formalize common extensions
+- Maintain all seven Social Web Recommendations (ActivityPub, ActivityStreams 2.0, Activity Vocabulary, Webmention, WebSub, Micropub, LDN)
+- Publish backwards-compatible updates incorporating accepted errata (expected Q3 2026)
+- Potentially adopt incubated work like LOLA (account portability) onto the Recommendation track
 
-This would allow modifications to the W3C Recommendations themselves, not just community extensions.
+The SocialCG continues to incubate new proposals, which the Working Group can adopt — modifications to the Recommendations themselves now happen in the WG.
 
 ### Focus Areas
 

--- a/docs/ecosystem/go-libraries.md
+++ b/docs/ecosystem/go-libraries.md
@@ -17,7 +17,11 @@ Comprehensive ActivityPub/ActivityStreams implementation.
 | Repository | [github.com/go-fed/activity](https://github.com/go-fed/activity) |
 | Documentation | [go-fed.org](https://go-fed.org/) |
 | License | BSD-3 |
-| Status | Active |
+| Status | Unmaintained (no activity since 2022) |
+
+:::caution Unmaintained
+go-fed/activity has had no development since 2022. It remains widely used and feature-complete, but expect no fixes or updates. For new Go projects, consider [go-ap](https://github.com/go-ap) or studying [GoToSocial's codebase](https://codeberg.org/superseriousbusiness/gotosocial).
+:::
 
 ### Features
 
@@ -111,7 +115,7 @@ HTTP Signature library.
 |----------|-------|
 | Repository | [github.com/go-fed/httpsig](https://github.com/go-fed/httpsig) |
 | License | BSD-3 |
-| Status | Active |
+| Status | Stable (low activity; widely used) |
 
 ### Signing
 

--- a/docs/ecosystem/gotosocial.md
+++ b/docs/ecosystem/gotosocial.md
@@ -182,9 +182,8 @@ Uses ULIDs instead of UUIDs:
 
 ### Known Differences
 
-- No quote posts
+- No quote posts yet (groundwork landed in v0.21 via the `canQuote` property)
 - No reactions (only Like)
-- No polls (yet)
 - Stricter signature validation
 
 ## Deployment

--- a/docs/ecosystem/hosting-providers.md
+++ b/docs/ecosystem/hosting-providers.md
@@ -158,9 +158,10 @@ Managed containers.
 Lightest option for personal use:
 
 ```bash
-# On a small VPS
-wget https://github.com/superseriousbusiness/gotosocial/releases/latest/download/gotosocial_linux_amd64.tar.gz
-tar -xzf gotosocial_linux_amd64.tar.gz
+# On a small VPS — get the latest release from Codeberg:
+# https://codeberg.org/superseriousbusiness/gotosocial/releases
+wget https://codeberg.org/superseriousbusiness/gotosocial/releases/download/v0.21.2/gotosocial_0.21.2_linux_amd64.tar.gz
+tar -xzf gotosocial_0.21.2_linux_amd64.tar.gz
 ./gotosocial server start
 ```
 
@@ -172,7 +173,7 @@ Most platforms provide Docker Compose files:
 version: '3'
 services:
   app:
-    image: tootsuite/mastodon:latest
+    image: ghcr.io/mastodon/mastodon:v4.5  # pin a specific version in production
     # ... configuration
   db:
     image: postgres:14

--- a/docs/ecosystem/javascript-libraries.md
+++ b/docs/ecosystem/javascript-libraries.md
@@ -95,14 +95,14 @@ import { resolve } from 'microfed/webfinger';
 Express.js middleware for ActivityPub.
 
 :::caution Unmaintained
-activitypub-express has had no activity since 2023 and is currently unmaintained. It still works for existing projects, but avoid it for new ones — see the [discussion on reviving it](https://github.com/socialdocs/socialdocs.org/issues/17).
+activitypub-express has had no activity since early 2024 and is currently unmaintained. It still works for existing projects, but avoid it for new ones — see the [discussion on reviving it](https://github.com/socialdocs/socialdocs.org/issues/17).
 :::
 
 | Property | Value |
 |----------|-------|
 | Repository | [github.com/immers-space/activitypub-express](https://github.com/immers-space/activitypub-express) |
 | License | MIT |
-| Status | Unmaintained (last activity 2023) |
+| Status | Unmaintained (last activity early 2024) |
 
 ### Features
 

--- a/docs/ecosystem/libraries-overview.md
+++ b/docs/ecosystem/libraries-overview.md
@@ -24,7 +24,7 @@ This page provides an overview of ActivityPub libraries available for different 
 
 | Library | Description | Status |
 |---------|-------------|--------|
-| [bovine](https://codeberg.org/bovine/bovine) | ActivityPub library | Active |
+| [bovine](https://codeberg.org/bovine/bovine) | ActivityPub library | Maintenance |
 | [little-boxes](https://github.com/tsileo/little-boxes) | ActivityPub toolkit | Maintenance |
 | [Federation](https://federation.readthedocs.io/) | Protocol support | Active |
 
@@ -72,7 +72,7 @@ This page provides an overview of ActivityPub libraries available for different 
 
 - **JavaScript**: Fedify (well-documented, active)
 - **Python**: bovine or little-boxes
-- **Go**: go-fed/activity (most complete)
+- **Go**: go-ap, or go-fed/activity (complete but unmaintained since 2022)
 
 ### For Production
 
@@ -114,7 +114,6 @@ This page provides an overview of ActivityPub libraries available for different 
 ### Production Ready
 
 - activitypub-federation (Rust)
-- go-fed/activity (Go)
 - Fedify (TypeScript)
 
 ### Stable
@@ -127,7 +126,8 @@ This page provides an overview of ActivityPub libraries available for different 
 
 ### Unmaintained
 
-- activitypub-express (JavaScript) — no activity since 2023
+- activitypub-express (JavaScript) — no activity since early 2024
+- go-fed/activity (Go) — no activity since 2022; feature-complete and still widely used
 
 ## Building Without a Library
 

--- a/docs/ecosystem/mastodon.md
+++ b/docs/ecosystem/mastodon.md
@@ -141,7 +141,7 @@ GET /users/{username}/following
 
 ### Known Issues
 
-- Quote posts not supported (planned)
+- Quote posts supported since v4.5 — quoting requires author approval, federated via `QuoteAuthorization`
 - Reactions not supported (only Like)
 - Local-only posts not federated
 

--- a/docs/ecosystem/misskey.md
+++ b/docs/ecosystem/misskey.md
@@ -20,11 +20,9 @@ Misskey is a feature-rich microblogging platform originating from Japan.
 
 ## Forks
 
-Misskey has several active forks:
-- **Firefish** (formerly Calckey)
-- **Sharkey**
-- **Foundkey**
-- **Akkoma** (Pleroma fork with Misskey compatibility)
+- **Sharkey** — the main actively maintained fork
+- **Firefish** (formerly Calckey) — discontinued
+- **Foundkey** — discontinued
 
 ## ActivityPub Implementation
 

--- a/docs/ecosystem/python-libraries.md
+++ b/docs/ecosystem/python-libraries.md
@@ -17,7 +17,7 @@ Modern ActivityPub library for Python.
 | Repository | [codeberg.org/bovine/bovine](https://codeberg.org/bovine/bovine) |
 | Documentation | [bovine.readthedocs.io](https://bovine.readthedocs.io/) |
 | License | MIT |
-| Status | Active |
+| Status | Maintenance (low activity since late 2025) |
 
 ### Features
 

--- a/docs/ecosystem/server-software.md
+++ b/docs/ecosystem/server-software.md
@@ -12,12 +12,14 @@ The Fediverse consists of many different server software implementations, each w
 
 ### Microblogging
 
-| Software | Language | Description | Active Users |
-|----------|----------|-------------|--------------|
+| Software | Language | Description | Registered Accounts |
+|----------|----------|-------------|---------------------|
 | [Mastodon](/docs/ecosystem/mastodon) | Ruby | Most popular, Twitter-like | ~10M+ |
 | [Pleroma](/docs/ecosystem/pleroma) | Elixir | Lightweight alternative | ~100K+ |
 | [Misskey](/docs/ecosystem/misskey) | TypeScript | Feature-rich, Japanese | ~500K+ |
 | [GoToSocial](/docs/ecosystem/gotosocial) | Go | Privacy-focused, lightweight | ~10K+ |
+
+Account magnitudes are approximate — see [FediDB](https://fedidb.org/) for live numbers.
 
 ### Link Aggregation
 

--- a/docs/ecosystem/w3c-groups.md
+++ b/docs/ecosystem/w3c-groups.md
@@ -140,7 +140,11 @@ All targeted for completion by Q3 2026:
 
 ### Tentative Deliverables
 
-**LOLA (Live Online Account Portability)** — May be adopted as Recommendation-track specification depending on incubation progress and implementer interest.
+**LOLA (Live Online Account Portability)** — May be adopted as Recommendation-track specification depending on incubation progress and implementer interest. As of mid-2026 it remains a [CG draft](https://swicg.github.io/activitypub-data-portability/lola) under development in the WG, with the Data Transfer Initiative co-authoring and building an implementer testbed.
+
+### Status (June 2026)
+
+Maintenance work is underway: accepted errata are being folded into the [ActivityPub Editor's Draft](https://w3c.github.io/activitypub/) (e.g. removal of the C2S `null` partial-update language, February 2026). The published 2018 Recommendation is unchanged so far — updated, backwards-compatible Recommendations are expected in Q3 2026.
 
 ### Coordination
 

--- a/docs/getting-started/what-is-the-fediverse.md
+++ b/docs/getting-started/what-is-the-fediverse.md
@@ -117,9 +117,9 @@ The Fediverse relies on several W3C standards:
 
 ## Scale of the Fediverse
 
-As of 2024, the Fediverse includes:
-- **10+ million** active users
-- **20,000+** independent servers
+As of mid-2026 ([FediDB](https://fedidb.org/)), the Fediverse includes:
+- **13+ million** registered accounts (over a million monthly active)
+- **40,000+** independent servers
 - **100+** different software implementations
 - Growing daily with new users and platforms
 

--- a/docs/specs/activitypub/overview.md
+++ b/docs/specs/activitypub/overview.md
@@ -10,8 +10,9 @@ ActivityPub is a W3C Recommendation that defines a protocol for decentralized so
 
 ## Specification
 
-- **Status**: W3C Recommendation (January 2018)
+- **Status**: W3C Recommendation (January 2018), under active maintenance by the rechartered [Social Web Working Group](/docs/ecosystem/w3c-groups) — a backwards-compatible update incorporating accepted errata is expected in late 2026
 - **URL**: [https://www.w3.org/TR/activitypub/](https://www.w3.org/TR/activitypub/)
+- **Editor's Draft**: [w3c.github.io/activitypub](https://w3c.github.io/activitypub/) — incorporates accepted errata ahead of the updated Recommendation
 - **Editors**: Christopher Lemmer Webber, Jessica Tallon, Erin Shepherd
 
 ## Two Protocols in One


### PR DESCRIPTION
Fixes #27

Site content was written in late December 2025. This refresh corrects everything that has drifted since, based on a deep-research workflow (25/25 claims verified 3-0 against primary sources) plus direct release-API checks, all on June 10, 2026.

## Stats
- "As of 2024: 10M+ active users, 20,000+ servers" → **13M+ registered accounts (~1.1M monthly active), 40,000+ servers** per [FediDB](https://fedidb.org/), with the "Active Users" table column renamed to "Registered Accounts" (the old label conflated the two)

## Standards
- **socialcg.md** said the W3C was "considering" a new Working Group — it was **rechartered January 15, 2026** (chair: Darius Kazemi); section rewritten with the seven maintained Recommendations and Q3 2026 target
- **specs/activitypub/overview.md** now notes active maintenance and links the Editor's Draft (which folds in accepted errata, e.g. the February 2026 removal of C2S `null` partial-update language)
- **w3c-groups.md** gains a June 2026 status note; LOLA explicitly marked as still a CG draft (not Rec-track), with the DTI testbed work noted

## Feature claims that became wrong
- **Mastodon**: "Quote posts not supported (planned)" → shipped in v4.5 with the `QuoteAuthorization` approval flow
- **GoToSocial**: "No polls (yet)" removed — GtS has polls; quote posts correctly remain pending (v0.21 landed `canQuote` groundwork only)

## Project statuses
- **misskey.md** fork list: Firefish and Foundkey marked discontinued, Sharkey is the active fork, Akkoma removed (it's a Pleroma fork and listed there)
- **go-fed/activity**: marked unmaintained (no activity since 2022) with a caution pointing to go-ap/GoToSocial; httpsig downgraded to "Stable (low activity)"
- **bovine**: Active → Maintenance (no activity since September 2025)
- **activitypub-express**: "since 2023" corrected to "early 2024" (last push 2024-02)

## Broken link fixed
- The GoToSocial quick-start `wget` URL pointed at GitHub releases, which now **404** (project moved to Codeberg) — replaced with the verified v0.21.2 Codeberg asset URL
- Mastodon Docker example now pins a version instead of `:latest`

## Events
- FediForum: next edition **October 6-7, 2026**, with a link to the events archive