### PR TITLE
Add notable recent FEPs and current statuses

### DIFF
--- a/docs/community/feps.md
+++ b/docs/community/feps.md
@@ -78,7 +78,8 @@ The official FEP repository is hosted on Codeberg:
 | FEP | Title | Status |
 |-----|-------|--------|
 | FEP-d556 | Server-Level Actor Discovery Using WebFinger | FINAL |
-| FEP-f1d5 | NodeInfo in Fediverse Software | FINAL |
+| FEP-0151 | NodeInfo in Fediverse Software (2025 edition) | FINAL (March 2026) |
+| FEP-f1d5 | NodeInfo in Fediverse Software | FINAL (superseded by FEP-0151) |
 | FEP-8fcf | Followers Collection Synchronization | FINAL |
 | FEP-ae0c | Fediverse Relay Protocols | FINAL |
 
@@ -95,6 +96,23 @@ The official FEP repository is hosted on Codeberg:
 | FEP | Title | Status |
 |-----|-------|--------|
 | FEP-521a | Representing Actor's Public Keys | FINAL |
+
+### Notable Drafts in Production
+
+These are still DRAFT status but already shape real-world interop (as of mid-2026):
+
+| FEP | Title | Who implements it |
+|-----|-------|-------------------|
+| [FEP-044f](https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md) | Consent-respecting quote posts (`QuoteRequest`/`QuoteAuthorization`, `canQuote`) | Mastodon 4.5+ (full), GoToSocial 0.21 (partial) |
+| [FEP-dd4b](https://codeberg.org/fediverse/fep/src/branch/main/fep/dd4b/fep-dd4b.md) | Quote Posts — alternative `Announce`-based approach | Proposal stage |
+| [FEP-8b32](https://codeberg.org/fediverse/fep/src/branch/main/fep/8b32/fep-8b32.md) | Object Integrity Proofs — self-authenticating activities | Mitra, Streams |
+| [FEP-7888](https://codeberg.org/fediverse/fep/src/branch/main/fep/7888/fep-7888.md) | Demystifying the `context` property — conversation grouping | NodeBB, Streams, Mitra |
+| [FEP-171b](https://codeberg.org/fediverse/fep/src/branch/main/fep/171b/fep-171b.md) | Conversation Containers — moderated conversation collections | Streams |
+| [FEP-ef61](https://codeberg.org/fediverse/fep/src/branch/main/fep/ef61/fep-ef61.md) | Portable Objects — server-independent IDs for nomadic identity | Mitra, Streams lineage |
+
+:::note Vendor drafts
+Mastodon 4.6's collections feature is based on "FEP-7aa9 (Featured Collections)" — but as of mid-2026 that draft lives in [Mastodon's own repository](https://github.com/mastodon/featured_collections) and has not been submitted to the canonical FEP repo. Vendor-published drafts can become FEPs later; check the [FEP repository](https://codeberg.org/fediverse/fep) for current status.
+:::
 
 ## FEP Identifiers
 


### PR DESCRIPTION
Fixes #30

Updates the FEPs page with verified statuses from the canonical repo (codeberg.org/fediverse/fep README, fetched June 10, 2026):

## Changes

- **FEP-0151** "NodeInfo in Fediverse Software (2025 edition)" added — the only FEP to reach FINAL since December 2025 (March 7, 2026); FEP-f1d5 marked superseded
- New **"Notable Drafts in Production"** table — DRAFT FEPs that already shape interop, each with verified implementers:
  - FEP-044f consent-respecting quote posts (Mastodon 4.5+ full, GoToSocial 0.21 partial via `canQuote`)
  - FEP-8b32 Object Integrity Proofs, FEP-7888 `context`, FEP-171b Conversation Containers, FEP-ef61 Portable Objects, FEP-dd4b
- **Vendor-draft caveat**: the research found that "FEP-7aa9 (Featured Collections)", which Mastodon 4.6 cites, is NOT in the canonical FEP repo — it's an unsubmitted draft in Mastodon's own repository. The note explains this rather than presenting it as a real FEP (correcting an overstatement in the original issue #30 text).

All six FEP document links verified resolving (200).